### PR TITLE
gradle: Enable -Werror; fix deprecation errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,7 @@ wpi.java.configureTestTasks(test)
 // Configure string concat to always inline compile
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
+    options.compilerArgs.add '-Werror'
 }
 
 spotless {

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,3 +28,4 @@ pluginManagement {
 
 Properties props = System.getProperties();
 props.setProperty("org.gradle.internal.native.headers.unresolved.dependencies.ignore", "true");
+props.setProperty("org.gradle.warning.mode", "all");

--- a/src/main/java/com/team973/frc2025/subsystems/composables/DriveWithTrajectory.java
+++ b/src/main/java/com/team973/frc2025/subsystems/composables/DriveWithTrajectory.java
@@ -79,10 +79,10 @@ public class DriveWithTrajectory extends DriveComposable {
     m_logger.log("sample/Heading Deg", Rotation2d.fromRadians(logSample.heading).getDegrees());
     m_logger.log("sample/Omega", logSample.omega);
 
-    m_logger.log("X Position Error", m_controller.getXController().getPositionError());
-    m_logger.log("X Velocity Error", m_controller.getXController().getVelocityError());
-    m_logger.log("Y Position Error", m_controller.getYController().getPositionError());
-    m_logger.log("Y Velocity Error", m_controller.getYController().getVelocityError());
+    m_logger.log("X Position Error", m_controller.getXController().getError());
+    m_logger.log("X Velocity Error", m_controller.getXController().getErrorDerivative());
+    m_logger.log("Y Position Error", m_controller.getYController().getError());
+    m_logger.log("Y Velocity Error", m_controller.getYController().getErrorDerivative());
     m_logger.log("Theta Position Error", m_controller.getThetaController().getPositionError());
     m_logger.log("Theta Velocity Error", m_controller.getThetaController().getVelocityError());
   }

--- a/src/main/java/com/team973/lib/util/Joystick.java
+++ b/src/main/java/com/team973/lib/util/Joystick.java
@@ -65,11 +65,12 @@ public class Joystick extends XboxController {
    * @return The value of raw button 5 if the controller is a sick stick. The value of the left
    *     bumper if it's an Xbox controller.
    */
-  public boolean getLeftBumper() {
+  @Override
+  public boolean getLeftBumperButton() {
     if (m_type == Type.SickStick) {
       return super.getRawButton(5);
     } else {
-      return super.getLeftBumper();
+      return super.getLeftBumperButton();
     }
   }
 
@@ -77,11 +78,12 @@ public class Joystick extends XboxController {
    * @return The value of raw button 5 pressed if the controller is a sick stick. The value of the
    *     left bumper pressed if it's an Xbox controller.
    */
-  public boolean getLeftBumperPressed() {
+  @Override
+  public boolean getLeftBumperButtonPressed() {
     if (m_type == Type.SickStick) {
       return super.getRawButtonPressed(5);
     } else {
-      return super.getLeftBumperPressed();
+      return super.getLeftBumperButtonPressed();
     }
   }
 
@@ -89,11 +91,12 @@ public class Joystick extends XboxController {
    * @return The value of raw button 5 released if the controller is a sick stick. The value of the
    *     left bumper released if it's an Xbox controller.
    */
-  public boolean getLeftBumperReleased() {
+  @Override
+  public boolean getLeftBumperButtonReleased() {
     if (m_type == Type.SickStick) {
       return super.getRawButtonReleased(5);
     } else {
-      return super.getLeftBumperReleased();
+      return super.getLeftBumperButtonReleased();
     }
   }
 
@@ -101,11 +104,12 @@ public class Joystick extends XboxController {
    * @return The value of raw button 6 if the controller is a sick stick. The value of the right
    *     bumper if it's an Xbox controller.
    */
-  public boolean getRightBumper() {
+  @Override
+  public boolean getRightBumperButton() {
     if (m_type == Type.SickStick) {
       return super.getRawButton(6);
     } else {
-      return super.getRightBumper();
+      return super.getRightBumperButton();
     }
   }
 
@@ -113,11 +117,12 @@ public class Joystick extends XboxController {
    * @return The value of raw button 6 pressed if the controller is a sick stick. The value of the
    *     right bumper pressed if it's an Xbox controller.
    */
-  public boolean getRightBumperPressed() {
+  @Override
+  public boolean getRightBumperButtonPressed() {
     if (m_type == Type.SickStick) {
       return super.getRawButtonPressed(6);
     } else {
-      return super.getRightBumperPressed();
+      return super.getRightBumperButtonPressed();
     }
   }
 
@@ -125,11 +130,12 @@ public class Joystick extends XboxController {
    * @return The value of raw button 6 released if the controller is a sick stick. The value of the
    *     left bumper released if it's an Xbox controller.
    */
-  public boolean getRightBumperReleased() {
+  @Override
+  public boolean getRightBumperButtonReleased() {
     if (m_type == Type.SickStick) {
       return super.getRawButtonReleased(6);
     } else {
-      return super.getRightBumperReleased();
+      return super.getRightBumperButtonReleased();
     }
   }
 
@@ -230,13 +236,13 @@ public class Joystick extends XboxController {
     m_logger.log("Right Trigger", this.getRightTrigger());
     m_logger.log("Right Trigger Released", this.getRightTriggerReleased());
 
-    m_logger.log("Left Bumper", this.getLeftBumper());
-    m_logger.log("Left Bumper Pressed", this.getLeftBumperPressed());
-    m_logger.log("Left Bumper Released", this.getLeftBumperReleased());
+    m_logger.log("Left Bumper", this.getLeftBumperButton());
+    m_logger.log("Left Bumper Pressed", this.getLeftBumperButtonPressed());
+    m_logger.log("Left Bumper Released", this.getLeftBumperButtonReleased());
 
-    m_logger.log("Right Bumper", this.getRightBumper());
-    m_logger.log("Right Bumper Pressed", this.getRightBumperPressed());
-    m_logger.log("Right Bumper Released", this.getRightBumperReleased());
+    m_logger.log("Right Bumper", this.getRightBumperButton());
+    m_logger.log("Right Bumper Pressed", this.getRightBumperButtonPressed());
+    m_logger.log("Right Bumper Released", this.getRightBumperButtonReleased());
 
     m_logger.log("A Button", this.getAButton());
     m_logger.log("A Button Pressed", this.getAButtonPressed());

--- a/src/main/java/com/team973/lib/util/StandardizedRotation3d.java
+++ b/src/main/java/com/team973/lib/util/StandardizedRotation3d.java
@@ -1,7 +1,5 @@
 package com.team973.lib.util;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.Vector;
 import edu.wpi.first.math.geometry.Quaternion;
@@ -41,8 +39,7 @@ public class StandardizedRotation3d extends Rotation3d {
    *
    * @param q The quaternion.
    */
-  @JsonCreator
-  public StandardizedRotation3d(@JsonProperty(required = true, value = "quaternion") Quaternion q) {
+  public StandardizedRotation3d(Quaternion q) {
     super(q);
   }
 


### PR DESCRIPTION
Adding -Werror turns compilation warnings into errors which makes us less likely to fix them. Gradle hides these by default unless you set org.gradle.warning.mode=all.

In order to get the build passing I needed to update Joystick.java to use non-deprecated methods of XBoxController.

StandardizedRotation3d proides some utilities around Rotation3d that add getters with units so I wanted to keep this, but I had to remove the json annotations because they were causing warnings. I don't think we use the json serializer/deserializers that the annotations were generating anywhere so I think it's fine to remove.