### PR TITLE
armivator: Do not zero on startup

### DIFF
--- a/src/main/java/com/team973/frc2025/subsystems/Arm.java
+++ b/src/main/java/com/team973/frc2025/subsystems/Arm.java
@@ -17,7 +17,10 @@ public class Arm implements Subsystem {
   private ControlStatus m_controlStatus = ControlStatus.Off;
   private double m_armTargetPostionDeg;
   private double m_manualArmPower;
-  private boolean m_lastHallSensorMode;
+  // We want to track the transition from hall=false to hall=true; when the robot
+  // first boots up, we don't really know what the previous hall state was, so we
+  // assume it was true to avoid false positive.
+  private boolean m_lastHallSensorMode = true;
   private final DigitalInput m_hallSesnsor = new DigitalInput(RobotInfo.ArmInfo.HALL_SENSOR_ID);
 
   private final SolidSignaler m_armHomedSigaler =

--- a/src/main/java/com/team973/frc2025/subsystems/Elevator.java
+++ b/src/main/java/com/team973/frc2025/subsystems/Elevator.java
@@ -22,7 +22,7 @@ public class Elevator implements Subsystem {
   private double m_targetpositionLeway = 0.1;
   double MOTOR_GEAR_RATIO = 10.0 / 56.0;
   private double m_manualPower;
-  private boolean m_lastHallSensorMode;
+  private boolean m_lastHallSensorMode = true;
   private final DigitalInput m_hallSensor = new DigitalInput(RobotInfo.ElevatorInfo.HALL_SENSOR_ID);
 
   private final SolidSignaler m_elevatorHomedBlinker =


### PR DESCRIPTION
I think the elevator was pushing down with considerable force because it was being reset to 0.25" height at bootup when in reality it was at 0.0" height.

With this change, we do not zero on bootup --- we only zero when we are sure that the hall sensor has transitioned from false to true.