### PR TITLE
Update Swerve Offset Doc

### DIFF
--- a/docs/UpdatingModuleOffsets.md
+++ b/docs/UpdatingModuleOffsets.md
@@ -1,6 +1,6 @@
 # Updating Module Offsets
 
 1. Face all of the swerve modules straight with the bevel gear to the left (make sure you know what the front of the robot is). Push a bar against the two modules on each side of the robot to make sure they are as straight as possible!
-2. Open up AdvantageScope and find the `Position in Degrees` print of each module.
-3. Replace the value of each `MODULE_OFFSET` constant with the print of the correspinding module. (mod0 = Front Left, mod1 = Front Right, mod2 = Back Left, mod3 = Back Right)
+2. Open up Phoenix Tuner and find the absolute position in degrees of each module's CANCoder.
+3. Replace the value of each `MODULE_OFFSET` constant with the print of the correspinding module.
 4. Test the robot and make sure that all of the modules drive in the correct direction.


### PR DESCRIPTION
Swerve offsets should be found by getting the absolute value of the CANCoders from Phoenix Tuner and converting them into degrees.