### PR TITLE
Subsystem States Refactor

### DIFF
--- a/src/main/java/com/team973/frc2025/subsystems/Arm.java
+++ b/src/main/java/com/team973/frc2025/subsystems/Arm.java
@@ -58,9 +58,6 @@ public class Arm extends Subsystem<Arm.State> {
 
     m_stateMap = new StateMap<>(State.class);
 
-    m_stateMap.put(State.TargetPostion);
-    m_stateMap.put(State.Off);
-
     candle.addSignaler(m_armHorizontalSigaler);
 
     TalonFXConfiguration armMotorConfig = new TalonFXConfiguration();

--- a/src/main/java/com/team973/frc2025/subsystems/Arm.java
+++ b/src/main/java/com/team973/frc2025/subsystems/Arm.java
@@ -44,6 +44,8 @@ public class Arm extends Subsystem<Arm.State> {
   }
 
   public Arm(Logger logger, CANdleManger candle) {
+    super(State.Off);
+
     m_robotInfo = RobotConfig.get();
     m_armInfo = m_robotInfo.ARM_INFO;
     m_logger = logger;

--- a/src/main/java/com/team973/frc2025/subsystems/CANdleManger.java
+++ b/src/main/java/com/team973/frc2025/subsystems/CANdleManger.java
@@ -10,7 +10,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-public class CANdleManger implements Subsystem {
+public class CANdleManger extends Subsystem.Stateless {
   public final CANdle m_candle = new CANdle(18, "rio");
 
   public List<ISignaler> m_priortyQue;

--- a/src/main/java/com/team973/frc2025/subsystems/Claw.java
+++ b/src/main/java/com/team973/frc2025/subsystems/Claw.java
@@ -65,16 +65,6 @@ public class Claw extends Subsystem<Claw.State> {
 
     m_stateMap = new StateMap<>(State.class);
 
-    m_stateMap.put(State.IntakeCoral);
-    m_stateMap.put(State.IntakeAlgae);
-    m_stateMap.put(State.IntakeAlgaeFromFloor);
-    m_stateMap.put(State.ScoreCoral);
-    m_stateMap.put(State.ScoreCoralLevelOne);
-    m_stateMap.put(State.ScoreAlgae);
-    m_stateMap.put(State.ScoreAlgaeProcessor);
-    m_stateMap.put(State.Reverse);
-    m_stateMap.put(State.Off);
-
     m_caNdle.addSignaler(m_clawHasPeiceSignaler);
     m_clawMotor =
         new GreyTalonFX(

--- a/src/main/java/com/team973/frc2025/subsystems/Claw.java
+++ b/src/main/java/com/team973/frc2025/subsystems/Claw.java
@@ -53,6 +53,8 @@ public class Claw extends Subsystem<Claw.State> {
   }
 
   public Claw(Logger logger, CANdleManger candle) {
+    super(State.Off);
+
     m_logger = logger;
     m_caNdle = candle;
     m_robotInfo = RobotConfig.get();

--- a/src/main/java/com/team973/frc2025/subsystems/Climb.java
+++ b/src/main/java/com/team973/frc2025/subsystems/Climb.java
@@ -11,7 +11,7 @@ import com.team973.lib.devices.GreyTalonFX;
 import com.team973.lib.util.Logger;
 import com.team973.lib.util.Subsystem;
 
-public class Climb implements Subsystem {
+public class Climb extends Subsystem.Stateless {
   private final RobotInfo m_robotInfo;
   private final RobotInfo.ClimbInfo m_climbInfo;
 

--- a/src/main/java/com/team973/frc2025/subsystems/Drive.java
+++ b/src/main/java/com/team973/frc2025/subsystems/Drive.java
@@ -56,8 +56,6 @@ public class Drive extends Subsystem.Stateless {
   private final MegaTagSupplier m_rightLLSupplier;
   private final MegaTagSupplier m_backLLSupplier;
 
-  public enum State {}
-
   public Drive(
       GreyPigeonIO pigeon,
       DriveController driveController,

--- a/src/main/java/com/team973/frc2025/subsystems/Drive.java
+++ b/src/main/java/com/team973/frc2025/subsystems/Drive.java
@@ -22,8 +22,8 @@ import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class Drive implements Subsystem {
-  private RobotInfo.DriveInfo m_driveInfo;
+public class Drive extends Subsystem.Stateless {
+  private final RobotInfo.DriveInfo m_driveInfo;
 
   private static final Translation2d[] MODULE_LOCATIONS = {
     new Translation2d(DriveInfo.TRACKWIDTH_METERS / 2.0, DriveInfo.WHEELBASE_METERS / 2.0),
@@ -55,6 +55,8 @@ public class Drive implements Subsystem {
   private final MegaTagSupplier m_leftLLSupplier;
   private final MegaTagSupplier m_rightLLSupplier;
   private final MegaTagSupplier m_backLLSupplier;
+
+  public enum State {}
 
   public Drive(
       GreyPigeonIO pigeon,

--- a/src/main/java/com/team973/frc2025/subsystems/DriveController.java
+++ b/src/main/java/com/team973/frc2025/subsystems/DriveController.java
@@ -76,10 +76,6 @@ public class DriveController extends Subsystem<DriveController.ControllerOption>
 
     m_controllerOptionMap = new StateMap<>(ControllerOption.class);
 
-    m_controllerOptionMap.put(ControllerOption.DriveWithJoysticks);
-    m_controllerOptionMap.put(ControllerOption.DriveWithTrajectory);
-    m_controllerOptionMap.put(ControllerOption.DriveWithLimelight);
-
     m_currentChassisSpeeds = new ChassisSpeeds();
   }
 

--- a/src/main/java/com/team973/frc2025/subsystems/Elevator.java
+++ b/src/main/java/com/team973/frc2025/subsystems/Elevator.java
@@ -14,15 +14,13 @@ import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.wpilibj.DigitalInput;
 
-public class Elevator implements ElevatorIO {
+public class Elevator extends ElevatorIO {
   private final RobotInfo.ElevatorInfo m_elevatorInfo;
 
   private final Logger m_logger;
 
   protected final GreyTalonFX m_motorRight;
   private final GreyTalonFX m_motorLeft;
-
-  private ControlStatus m_controlStatus = ControlStatus.Off;
 
   private double m_targetPostionHeightinches;
   private double m_targetpositionLeway = 0.1;
@@ -51,12 +49,6 @@ public class Elevator implements ElevatorIO {
   private CANdleManger m_candleManger;
 
   private boolean m_hallZeroingEnabled = true;
-
-  public static enum ControlStatus {
-    TargetPostion,
-    Zero,
-    Off,
-  }
 
   private double heightInchesToMotorRotations(double postionHeight) {
     return postionHeight / m_elevatorInfo.MOTOR_ROT_TO_HEIGHT_INCHES;
@@ -149,10 +141,6 @@ public class Elevator implements ElevatorIO {
     m_elevatorHomedCount++;
   }
 
-  public void setControlStatus(ControlStatus status) {
-    m_controlStatus = status;
-  }
-
   private boolean motorAtTarget(double motorRot) {
     return (Math.abs(m_targetPostionHeightinches - motorRotationsToHeightInches(motorRot))
         < m_targetpositionLeway);
@@ -164,7 +152,7 @@ public class Elevator implements ElevatorIO {
 
   public void setTargetPostion(double targetPostionHeightinches) {
     m_targetPostionHeightinches = targetPostionHeightinches;
-    m_controlStatus = ControlStatus.TargetPostion;
+    setState(State.TargetPostion);
   }
 
   public void incrementOffset(double offset, ReefLevel level) {
@@ -233,7 +221,7 @@ public class Elevator implements ElevatorIO {
 
   @Override
   public void update() {
-    switch (m_controlStatus) {
+    switch (getState()) {
       case TargetPostion:
         m_motorRight.setControl(
             ControlMode.MotionMagicVoltage,
@@ -264,7 +252,7 @@ public class Elevator implements ElevatorIO {
     m_logger.log("targetPostionReached", motorAtTarget(motorRightRot));
     m_logger.log("targetPostionHeightInches", m_targetPostionHeightinches);
 
-    m_logger.log("elevatorMode", m_controlStatus.toString());
+    m_logger.log("elevatorMode", getState().toString());
 
     m_logger.log("hallSesnsorReturnElevator", hallsensor());
 

--- a/src/main/java/com/team973/frc2025/subsystems/ElevatorIO.java
+++ b/src/main/java/com/team973/frc2025/subsystems/ElevatorIO.java
@@ -18,10 +18,6 @@ public abstract class ElevatorIO extends Subsystem<ElevatorIO.State> {
     super(State.Off);
 
     m_stateMap = new StateMap<>(State.class);
-
-    m_stateMap.put(State.TargetPostion);
-    m_stateMap.put(State.Zero);
-    m_stateMap.put(State.Off);
   }
 
   public StateMap<State> getStateMap() {

--- a/src/main/java/com/team973/frc2025/subsystems/ElevatorIO.java
+++ b/src/main/java/com/team973/frc2025/subsystems/ElevatorIO.java
@@ -1,27 +1,48 @@
 package com.team973.frc2025.subsystems;
 
 import com.team973.frc2025.subsystems.Superstructure.ReefLevel;
+import com.team973.lib.util.StateMap;
 import com.team973.lib.util.Subsystem;
 import edu.wpi.first.math.geometry.Pose3d;
 
-public interface ElevatorIO extends Subsystem {
-  public void setHallZeroingEnabled(boolean zeroingMode);
+public abstract class ElevatorIO extends Subsystem<ElevatorIO.State> {
+  private final StateMap<State> m_stateMap;
 
-  public void home();
+  public enum State {
+    TargetPostion,
+    Zero,
+    Off
+  }
 
-  public void setControlStatus(Elevator.ControlStatus status);
+  public ElevatorIO() {
+    super(State.Off);
 
-  public boolean motorAtTarget();
+    m_stateMap = new StateMap<>(State.class);
 
-  public void setTargetPostion(double targetPostionHeightinches);
+    m_stateMap.put(State.TargetPostion);
+    m_stateMap.put(State.Zero);
+    m_stateMap.put(State.Off);
+  }
 
-  public void incrementOffset(double offset, ReefLevel level);
+  public StateMap<State> getStateMap() {
+    return m_stateMap;
+  }
 
-  public double getTargetPosition();
+  public abstract void setHallZeroingEnabled(boolean zeroingMode);
 
-  public double getTargetPositionFromLevel(ReefLevel level);
+  public abstract void home();
 
-  public double getHeightInchesFromMotorRot(double motorRot);
+  public abstract boolean motorAtTarget();
 
-  public Pose3d getPose();
+  public abstract void setTargetPostion(double targetPostionHeightinches);
+
+  public abstract void incrementOffset(double offset, ReefLevel level);
+
+  public abstract double getTargetPosition();
+
+  public abstract double getTargetPositionFromLevel(ReefLevel level);
+
+  public abstract double getHeightInchesFromMotorRot(double motorRot);
+
+  public abstract Pose3d getPose();
 }

--- a/src/main/java/com/team973/frc2025/subsystems/Superstructure.java
+++ b/src/main/java/com/team973/frc2025/subsystems/Superstructure.java
@@ -4,6 +4,7 @@ import com.team973.frc2025.RobotConfig;
 import com.team973.frc2025.shared.RobotInfo;
 import com.team973.frc2025.shared.RobotInfo.Colors;
 import com.team973.frc2025.shared.RobotInfo.SignalerInfo;
+import com.team973.frc2025.subsystems.composables.DriveWithLimelight;
 import com.team973.frc2025.subsystems.composables.DriveWithLimelight.ReefFace;
 import com.team973.lib.util.Logger;
 import com.team973.lib.util.Subsystem;
@@ -45,8 +46,7 @@ public class Superstructure implements Subsystem {
     Manual,
     Score,
     Zero,
-    Climb,
-    Off
+    Climb
   }
 
   public enum ReefLevel {
@@ -105,8 +105,20 @@ public class Superstructure implements Subsystem {
     m_manualScore = score;
   }
 
+  public boolean getManualScore() {
+    return m_manualScore;
+  }
+
   public void setManualIntake(boolean intake) {
     m_manualIntake = intake;
+  }
+
+  public boolean getManualIntake() {
+    return m_manualIntake;
+  }
+
+  public boolean getManualArmivator() {
+    return m_manualArmivator;
   }
 
   private void setTargetReefLevelSupplier(Supplier<ReefLevel> reefLevelSupplier) {
@@ -249,12 +261,12 @@ public class Superstructure implements Subsystem {
     }
   }
 
-  private void armTargetReefLevel() {
+  public void armTargetReefLevel() {
     m_arm.setTargetDeg(m_arm.getTargetDegFromLevel(m_targetReefLevelSupplier.get()));
     m_arm.setControlStatus(Arm.ControlStatus.TargetPostion);
   }
 
-  private void armStow() {
+  public void armStow() {
     if (m_gamePieceMode == GamePiece.Coral) {
       m_arm.setTargetDeg(m_armInfo.CORAL_STOW_POSITION_DEG);
     } else {
@@ -263,13 +275,13 @@ public class Superstructure implements Subsystem {
     m_arm.setControlStatus(Arm.ControlStatus.TargetPostion);
   }
 
-  private void elevatorTargetReefLevel() {
+  public void elevatorTargetReefLevel() {
     m_elevator.setTargetPostion(
         m_elevator.getTargetPositionFromLevel(m_targetReefLevelSupplier.get()));
     m_elevator.setControlStatus(Elevator.ControlStatus.TargetPostion);
   }
 
-  private void elevatorStow() {
+  public void elevatorStow() {
     if (m_gamePieceMode == GamePiece.Coral) {
       m_elevator.setTargetPostion(m_elevatorInfo.CORAL_STOW);
     } else {
@@ -278,7 +290,7 @@ public class Superstructure implements Subsystem {
     m_elevator.setControlStatus(Elevator.ControlStatus.TargetPostion);
   }
 
-  private void wristStow() {
+  public void wristStow() {
     if (m_gamePieceMode == GamePiece.Coral) {
       m_wrist.setTargetDeg(m_wristInfo.WITHOUT_CORAL_STOW_POSITION_DEG);
     } else {
@@ -287,7 +299,7 @@ public class Superstructure implements Subsystem {
     m_wrist.setControlStatus(Wrist.ControlStatus.TargetPostion);
   }
 
-  private void wristTargetReefLevel() {
+  public void wristTargetReefLevel() {
     m_wrist.setTargetDeg(m_wrist.getTargetDegFromLevel(m_targetReefLevelSupplier.get()));
     m_wrist.setControlStatus(Wrist.ControlStatus.TargetPostion);
   }
@@ -369,6 +381,18 @@ public class Superstructure implements Subsystem {
     }
   }
 
+  public void clawReverse() {
+    m_claw.setControl(Claw.ControlStatus.Reverse);
+  }
+
+  public void clawOff() {
+    m_claw.setControl(Claw.ControlStatus.Off);
+  }
+
+  public void zeroElevator() {
+    m_elevator.setControlStatus(Elevator.ControlStatus.Zero);
+  }
+
   public boolean getHasAlgae() {
     return m_claw.getHasAlgae();
   }
@@ -383,6 +407,14 @@ public class Superstructure implements Subsystem {
 
   public ReefLevel getTargetReefLevel() {
     return m_targetReefLevelSupplier.get();
+  }
+
+  public DriveWithLimelight.TargetStage getDriveWithLimelightTargetStage() {
+    return m_driveController.getDriveWithLimelight().getTargetStage();
+  }
+
+  public boolean isDriveNearApproach() {
+    return m_driveController.isNearApproach();
   }
 
   public void update() {
@@ -492,12 +524,6 @@ public class Superstructure implements Subsystem {
         wristTargetReefLevel();
 
         m_manualArmivator = true;
-        break;
-      case Off:
-        m_claw.setControl(Claw.ControlStatus.Off);
-        m_arm.setControlStatus(Arm.ControlStatus.Off);
-        m_elevator.setControlStatus(Elevator.ControlStatus.Off);
-        m_wrist.setControlStatus(Wrist.ControlStatus.Off);
         break;
     }
 

--- a/src/main/java/com/team973/frc2025/subsystems/Superstructure.java
+++ b/src/main/java/com/team973/frc2025/subsystems/Superstructure.java
@@ -70,6 +70,7 @@ public class Superstructure extends Subsystem<Superstructure.State> {
     Algae
   }
 
+  @SuppressWarnings("unchecked")
   public Superstructure(
       Claw claw,
       Climb climb,
@@ -93,12 +94,13 @@ public class Superstructure extends Subsystem<Superstructure.State> {
 
     m_logger = logger;
 
-    m_stateMap = new StateMap<>(State.class);
-
-    m_stateMap.put(State.Manual, new ManualState(this));
-    m_stateMap.put(State.Score, new ScoreState(this));
-    m_stateMap.put(State.Zero, new ZeroState(this));
-    m_stateMap.put(State.Climb, new ClimbState(this));
+    m_stateMap =
+        new StateMap<>(
+            State.class,
+            new StateMap.Entry<State>(State.Manual, new ManualState(this)),
+            new StateMap.Entry<State>(State.Score, new ScoreState(this)),
+            new StateMap.Entry<State>(State.Zero, new ZeroState(this)),
+            new StateMap.Entry<State>(State.Climb, new ClimbState(this)));
 
     candle.addSignaler(m_algaeSignaler);
   }

--- a/src/main/java/com/team973/frc2025/subsystems/Wrist.java
+++ b/src/main/java/com/team973/frc2025/subsystems/Wrist.java
@@ -38,9 +38,6 @@ public class Wrist extends Subsystem<Wrist.State> {
 
     m_stateMap = new StateMap<>(State.class);
 
-    m_stateMap.put(State.TargetPostion);
-    m_stateMap.put(State.Off);
-
     m_wristMotor =
         new GreyTalonFX(
             m_wristInfo.MOTOR_CAN_ID, RobotInfo.CANIVORE_CANBUS, m_logger.subLogger("WristMotor"));

--- a/src/main/java/com/team973/frc2025/subsystems/states/ClimbState.java
+++ b/src/main/java/com/team973/frc2025/subsystems/states/ClimbState.java
@@ -1,0 +1,27 @@
+package com.team973.frc2025.subsystems.states;
+
+import com.team973.frc2025.subsystems.Superstructure;
+import com.team973.frc2025.subsystems.Superstructure.ReefLevel;
+import com.team973.lib.util.SubsystemState;
+
+public class ClimbState implements SubsystemState {
+  private final Superstructure m_superstructure;
+
+  public ClimbState(Superstructure superstructure) {
+    m_superstructure = superstructure;
+  }
+
+  public void init() {}
+
+  public void run() {
+    m_superstructure.clawOff();
+
+    m_superstructure.setTargetReefLevel(ReefLevel.Horizontal);
+
+    m_superstructure.armTargetReefLevel();
+    m_superstructure.elevatorTargetReefLevel();
+    m_superstructure.wristTargetReefLevel();
+
+    m_superstructure.setManualArmivator(true);
+  }
+}

--- a/src/main/java/com/team973/frc2025/subsystems/states/ClimbState.java
+++ b/src/main/java/com/team973/frc2025/subsystems/states/ClimbState.java
@@ -24,4 +24,6 @@ public class ClimbState implements SubsystemState {
 
     m_superstructure.setManualArmivator(true);
   }
+
+  public void exit() {}
 }

--- a/src/main/java/com/team973/frc2025/subsystems/states/ManualState.java
+++ b/src/main/java/com/team973/frc2025/subsystems/states/ManualState.java
@@ -34,4 +34,6 @@ public class ManualState implements SubsystemState {
       m_superstructure.wristStow();
     }
   }
+
+  public void exit() {}
 }

--- a/src/main/java/com/team973/frc2025/subsystems/states/ManualState.java
+++ b/src/main/java/com/team973/frc2025/subsystems/states/ManualState.java
@@ -1,0 +1,37 @@
+package com.team973.frc2025.subsystems.states;
+
+import com.team973.frc2025.subsystems.Superstructure;
+import com.team973.lib.util.SubsystemState;
+
+public class ManualState implements SubsystemState {
+  private final Superstructure m_superstructure;
+
+  public ManualState(Superstructure superstructure) {
+    m_superstructure = superstructure;
+  }
+
+  public void init() {
+    m_superstructure.setManualScore(false);
+    m_superstructure.setManualIntake(true);
+  }
+
+  public void run() {
+    if (m_superstructure.getManualScore()) {
+      m_superstructure.clawScore();
+    } else if (m_superstructure.getManualIntake()) {
+      m_superstructure.clawIntake();
+    } else {
+      m_superstructure.clawReverse();
+    }
+
+    if (m_superstructure.getManualArmivator()) {
+      m_superstructure.armTargetReefLevel();
+      m_superstructure.elevatorTargetReefLevel();
+      m_superstructure.wristTargetReefLevel();
+    } else {
+      m_superstructure.armStow();
+      m_superstructure.elevatorStow();
+      m_superstructure.wristStow();
+    }
+  }
+}

--- a/src/main/java/com/team973/frc2025/subsystems/states/ScoreState.java
+++ b/src/main/java/com/team973/frc2025/subsystems/states/ScoreState.java
@@ -1,0 +1,80 @@
+package com.team973.frc2025.subsystems.states;
+
+import com.team973.frc2025.subsystems.Superstructure;
+import com.team973.frc2025.subsystems.Superstructure.GamePiece;
+import com.team973.frc2025.subsystems.Superstructure.ReefLevel;
+import com.team973.lib.util.SubsystemState;
+import edu.wpi.first.wpilibj.DriverStation;
+
+public class ScoreState implements SubsystemState {
+  private final Superstructure m_superstructure;
+
+  public ScoreState(Superstructure superstructure) {
+    m_superstructure = superstructure;
+  }
+
+  public void init() {
+    m_superstructure.setManualScore(false);
+  }
+
+  public void run() {
+    m_superstructure.clawIntake();
+
+    switch (m_superstructure.getDriveWithLimelightTargetStage()) {
+      case MoveToApproach:
+        if (m_superstructure.isDriveNearApproach()) {
+          m_superstructure.armTargetReefLevel();
+          m_superstructure.wristTargetReefLevel();
+          m_superstructure.elevatorTargetReefLevel();
+
+          m_superstructure.setManualArmivator(true);
+        }
+        break;
+      case Approach:
+        m_superstructure.armTargetReefLevel();
+        m_superstructure.elevatorTargetReefLevel();
+        m_superstructure.wristTargetReefLevel();
+
+        m_superstructure.setManualArmivator(true);
+        break;
+      case MoveToScoring:
+        m_superstructure.armTargetReefLevel();
+        m_superstructure.elevatorTargetReefLevel();
+        m_superstructure.wristTargetReefLevel();
+        break;
+      case Scoring:
+        if (m_superstructure.getManualScore()
+            && (m_superstructure.getGamePieceMode() == GamePiece.Coral
+                || m_superstructure.getTargetReefLevel() == ReefLevel.Processor
+                || m_superstructure.getTargetReefLevel() == ReefLevel.Net)) {
+          m_superstructure.clawScore();
+        }
+
+        m_superstructure.armTargetReefLevel();
+        m_superstructure.elevatorTargetReefLevel();
+        m_superstructure.wristTargetReefLevel();
+        break;
+      case MoveToBackOff:
+        if (m_superstructure.getGamePieceMode() == GamePiece.Coral) {
+          m_superstructure.clawOff();
+        } else {
+          m_superstructure.clawIntake();
+        }
+
+        m_superstructure.armTargetReefLevel();
+        m_superstructure.elevatorTargetReefLevel();
+        m_superstructure.wristTargetReefLevel();
+        break;
+      case BackOff:
+        if (m_superstructure.getGamePieceMode() == GamePiece.Coral || DriverStation.isTeleop()) {
+          m_superstructure.armStow();
+          m_superstructure.elevatorStow();
+          m_superstructure.wristStow();
+
+          m_superstructure.setManualArmivator(false);
+        }
+
+        break;
+    }
+  }
+}

--- a/src/main/java/com/team973/frc2025/subsystems/states/ScoreState.java
+++ b/src/main/java/com/team973/frc2025/subsystems/states/ScoreState.java
@@ -77,4 +77,6 @@ public class ScoreState implements SubsystemState {
         break;
     }
   }
+
+  public void exit() {}
 }

--- a/src/main/java/com/team973/frc2025/subsystems/states/ZeroState.java
+++ b/src/main/java/com/team973/frc2025/subsystems/states/ZeroState.java
@@ -1,0 +1,22 @@
+package com.team973.frc2025.subsystems.states;
+
+import com.team973.frc2025.subsystems.Superstructure;
+import com.team973.lib.util.SubsystemState;
+
+public class ZeroState implements SubsystemState {
+  private final Superstructure m_superstructure;
+
+  public ZeroState(Superstructure superstructure) {
+    m_superstructure = superstructure;
+  }
+
+  public void init() {}
+
+  public void run() {
+    m_superstructure.zeroElevator();
+
+    m_superstructure.wristStow();
+    m_superstructure.armStow();
+    m_superstructure.clawIntake();
+  }
+}

--- a/src/main/java/com/team973/frc2025/subsystems/states/ZeroState.java
+++ b/src/main/java/com/team973/frc2025/subsystems/states/ZeroState.java
@@ -19,4 +19,8 @@ public class ZeroState implements SubsystemState {
     m_superstructure.armStow();
     m_superstructure.clawIntake();
   }
+
+  public void exit() {
+    m_superstructure.homeElevator();
+  }
 }

--- a/src/main/java/com/team973/lib/util/StateMap.java
+++ b/src/main/java/com/team973/lib/util/StateMap.java
@@ -2,7 +2,9 @@ package com.team973.lib.util;
 
 import java.util.EnumMap;
 
-public class StateMap<K extends Enum<K>> extends EnumMap<K, SubsystemState> {
+public class StateMap<K extends Enum<K>> {
+  private final EnumMap<K, SubsystemState> m_enumMap;
+
   private class EmptySubsystemState implements SubsystemState {
     public void init() {}
 
@@ -30,7 +32,7 @@ public class StateMap<K extends Enum<K>> extends EnumMap<K, SubsystemState> {
   }
 
   public StateMap(Class<K> stateType) {
-    super(stateType);
+    m_enumMap = new EnumMap<>(stateType);
 
     for (K key : stateType.getEnumConstants()) {
       put(key);
@@ -39,14 +41,18 @@ public class StateMap<K extends Enum<K>> extends EnumMap<K, SubsystemState> {
 
   @SuppressWarnings("unchecked")
   public StateMap(Class<K> stateType, Entry<K>... entries) {
-    super(stateType);
+    m_enumMap = new EnumMap<>(stateType);
 
     for (Entry<K> e : entries) {
-      put(e.getKey(), e.getState());
+      m_enumMap.put(e.getKey(), e.getState());
     }
   }
 
   private void put(K state) {
-    put(state, new EmptySubsystemState());
+    m_enumMap.put(state, new EmptySubsystemState());
+  }
+
+  public SubsystemState get(K key) {
+    return m_enumMap.get(key);
   }
 }

--- a/src/main/java/com/team973/lib/util/StateMap.java
+++ b/src/main/java/com/team973/lib/util/StateMap.java
@@ -1,0 +1,21 @@
+package com.team973.lib.util;
+
+import java.util.EnumMap;
+
+public class StateMap<K extends Enum<K>> extends EnumMap<K, SubsystemState> {
+  private class EmptySubsystemState implements SubsystemState {
+    public void init() {}
+
+    public void run() {}
+
+    public void exit() {}
+  }
+
+  public StateMap(Class<K> stateType) {
+    super(stateType);
+  }
+
+  public void put(K state) {
+    put(state, new EmptySubsystemState());
+  }
+}

--- a/src/main/java/com/team973/lib/util/StateMap.java
+++ b/src/main/java/com/team973/lib/util/StateMap.java
@@ -11,11 +11,42 @@ public class StateMap<K extends Enum<K>> extends EnumMap<K, SubsystemState> {
     public void exit() {}
   }
 
-  public StateMap(Class<K> stateType) {
-    super(stateType);
+  public static class Entry<K extends Enum<K>> {
+    private final K m_key;
+    private final SubsystemState m_state;
+
+    public Entry(K key, SubsystemState state) {
+      m_key = key;
+      m_state = state;
+    }
+
+    public K getKey() {
+      return m_key;
+    }
+
+    public SubsystemState getState() {
+      return m_state;
+    }
   }
 
-  public void put(K state) {
+  public StateMap(Class<K> stateType) {
+    super(stateType);
+
+    for (K key : stateType.getEnumConstants()) {
+      put(key);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  public StateMap(Class<K> stateType, Entry<K>... entries) {
+    super(stateType);
+
+    for (Entry<K> e : entries) {
+      put(e.getKey(), e.getState());
+    }
+  }
+
+  private void put(K state) {
     put(state, new EmptySubsystemState());
   }
 }

--- a/src/main/java/com/team973/lib/util/Subsystem.java
+++ b/src/main/java/com/team973/lib/util/Subsystem.java
@@ -2,14 +2,22 @@ package com.team973.lib.util;
 
 /** Base interface for all subsystems */
 public abstract class Subsystem<K extends Enum<K>> {
-  public abstract static class Stateless extends Subsystem<Stateless.EmptyEnum> {
-    private final StateMap<EmptyEnum> m_stateMap = new StateMap<>(EmptyEnum.class);
+  public abstract static class Stateless extends Subsystem<Stateless.FakeState> {
+    private final StateMap<FakeState> m_stateMap = new StateMap<>(FakeState.class);
 
-    public enum EmptyEnum {}
+    public enum FakeState {
+      InitialState
+    }
 
-    public StateMap<EmptyEnum> getStateMap() {
+    public Stateless() {
+      super(FakeState.InitialState);
+    }
+
+    public StateMap<FakeState> getStateMap() {
       return m_stateMap;
     }
+
+    public abstract void update();
   }
 
   private K m_currentState;
@@ -19,8 +27,6 @@ public abstract class Subsystem<K extends Enum<K>> {
     m_currentState = initialState;
     m_lastState = initialState;
   }
-
-  public Subsystem() {}
 
   public abstract StateMap<K> getStateMap();
 
@@ -51,9 +57,6 @@ public abstract class Subsystem<K extends Enum<K>> {
    * on the subsystem.
    */
   public abstract void syncSensors();
-
-  /** Update the subsystem. Call this periodically when the robot is enabled. */
-  // public abstract void update();
 
   /** Reset the subsystem. */
   public abstract void reset();

--- a/src/main/java/com/team973/lib/util/Subsystem.java
+++ b/src/main/java/com/team973/lib/util/Subsystem.java
@@ -1,20 +1,60 @@
 package com.team973.lib.util;
 
 /** Base interface for all subsystems */
-public interface Subsystem {
+public abstract class Subsystem<K extends Enum<K>> {
+  public abstract static class Stateless extends Subsystem<Stateless.EmptyEnum> {
+    private final StateMap<EmptyEnum> m_stateMap = new StateMap<>(EmptyEnum.class);
+
+    public enum EmptyEnum {}
+
+    public StateMap<EmptyEnum> getStateMap() {
+      return m_stateMap;
+    }
+  }
+
+  private K m_currentState;
+  private K m_lastState;
+
+  public Subsystem(K initialState) {
+    m_currentState = initialState;
+    m_lastState = initialState;
+  }
+
+  public Subsystem() {}
+
+  public abstract StateMap<K> getStateMap();
+
+  public void setState(K state) {
+    m_currentState = state;
+  }
+
+  public K getState() {
+    return m_currentState;
+  }
+
+  public void update() {
+    if (m_currentState != m_lastState) {
+      getStateMap().get(m_lastState).exit();
+      getStateMap().get(m_currentState).init();
+    }
+
+    getStateMap().get(m_currentState).run();
+
+    m_lastState = m_currentState;
+  }
 
   /** Log subsystem data. Called while the robot is on. */
-  public void log();
+  public abstract void log();
 
   /**
    * Update the sensors in the subsystem. This should be called before doing any calculations based
    * on the subsystem.
    */
-  public void syncSensors();
+  public abstract void syncSensors();
 
   /** Update the subsystem. Call this periodically when the robot is enabled. */
-  public void update();
+  // public abstract void update();
 
   /** Reset the subsystem. */
-  public void reset();
+  public abstract void reset();
 }

--- a/src/main/java/com/team973/lib/util/Subsystem.java
+++ b/src/main/java/com/team973/lib/util/Subsystem.java
@@ -2,18 +2,18 @@ package com.team973.lib.util;
 
 /** Base interface for all subsystems */
 public abstract class Subsystem<K extends Enum<K>> {
-  public abstract static class Stateless extends Subsystem<Stateless.FakeState> {
-    private final StateMap<FakeState> m_stateMap = new StateMap<>(FakeState.class);
+  public abstract static class Stateless extends Subsystem<Stateless.State> {
+    private final StateMap<State> m_stateMap = new StateMap<>(State.class);
 
-    public enum FakeState {
-      InitialState
+    public enum State {
+      SingleState
     }
 
     public Stateless() {
-      super(FakeState.InitialState);
+      super(State.SingleState);
     }
 
-    public StateMap<FakeState> getStateMap() {
+    public StateMap<State> getStateMap() {
       return m_stateMap;
     }
 

--- a/src/main/java/com/team973/lib/util/SubsystemState.java
+++ b/src/main/java/com/team973/lib/util/SubsystemState.java
@@ -4,4 +4,6 @@ public interface SubsystemState {
   public void init();
 
   public void run();
+
+  public void exit();
 }

--- a/src/main/java/com/team973/lib/util/SubsystemState.java
+++ b/src/main/java/com/team973/lib/util/SubsystemState.java
@@ -1,0 +1,7 @@
+package com.team973.lib.util;
+
+public interface SubsystemState {
+  public void init();
+
+  public void run();
+}


### PR DESCRIPTION
This PR:
- Adds a `SubsystemState` interface with `init`, `run`, and `exit` methods
- Adds four implementations of `SubsystemState` for the four states of the Superstructure (`Manual`, `Score`, `Zero`, and `Climb`)
- Turns the `Subsystem` interface into an abstract class that keeps track of the current state
- Uses a Map within the `Subsystem` class that (optionally) links the Enum state values of a subsystem to implementations of `SubsystemState` and runs the `init`, `run`, and `exit` methods at the appropriate time